### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 authors = ["Thijn Smulders <thijnsmulders04@gmail.com>"]
 description = "A simple logging library for Rust"
 license = "AGPL-3.0"
-homepage = "https://github.com/thijnmens/Apollo"
+repository = "https://github.com/thijnmens/Apollo"
 
 [dependencies]
 backtrace = "0.3.75"


### PR DESCRIPTION
According to the [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/91